### PR TITLE
Allow to disable configuration in hierarchy

### DIFF
--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -29,7 +29,10 @@ parameters:
               credentialsSecret:
                 name: other-foo
 
+      disabled: null
+
     secrets:
+      disabled: null
       foo-keycloak:
         stingData:
           username: foo


### PR DESCRIPTION
* Removes `null` objects in `parameters.secrets` and `parameters.sync` that may have been set via hierarchy, otherwise there's compilation errors.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
