### PR TITLE
Ensure operator and CRD are installed before applying resources

### DIFF
--- a/component/config.jsonnet
+++ b/component/config.jsonnet
@@ -41,6 +41,9 @@ local groupSyncs = std.filter(
             name: k,
             namespace: params.namespace,
             labels+: labels,
+            annotations+: {
+              'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+            },
           },
           spec: {
             providers: [

--- a/tests/golden/defaults/group-sync-operator/group-sync-operator/02_groupsync.yaml
+++ b/tests/golden/defaults/group-sync-operator/group-sync-operator/02_groupsync.yaml
@@ -1,6 +1,8 @@
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: GroupSync
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: group-sync-operator
@@ -32,6 +34,8 @@ spec:
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: GroupSync
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: group-sync-operator


### PR DESCRIPTION
* ArgoCD can fail the sync for CR if the CRD is not yet installed. This annotation should ensure that the operator and CRD are installed before.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
